### PR TITLE
Removed sorting fields in header

### DIFF
--- a/osmosis/models.py
+++ b/osmosis/models.py
@@ -314,7 +314,7 @@ class AbstractImportTask(models.Model):
                     # If this is the first row, write the column headers
                     if not has_written:
                         data = json.loads(shard.source_data_json)[0]
-                        cols = getattr(self, "detected_columns", sorted(data.keys())) + [ "errors" ]
+                        cols = getattr(self, "detected_columns", data.keys()) + [ "errors" ]
                         csvwriter = csv.writer(f)
                         csvwriter.writerow(cols)
                         has_written = True


### PR DESCRIPTION
When we created a final error_csv file, we were sorting columns in the header alphabetically, which resulted in header columns being in a different order than the rows below it. This PR removed the unnecessary sorting.