### PR TITLE
Refresh ImportTask object in finish method to avoid inconsistency

### DIFF
--- a/osmosis/models.py
+++ b/osmosis/models.py
@@ -287,6 +287,8 @@ class AbstractImportTask(models.Model):
         """
         Called when all shards have finished processing
         """
+        # Refresh object
+        self = self._meta.model.objects.get(pk=self.pk)
 
         # If this was called before, don't do anything
         if self.status == ImportStatus.FINISHED:


### PR DESCRIPTION
Soo.. turns out that if `finish` gets called twice, and we're dealing with lack of consistency, it will try to gather errors from shards into one file again, but we're deleting those file after we first called `finish`. This is causing CloudStorage to raise 404 and everything breaks.